### PR TITLE
Non static methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,30 @@ Examples of usage of the Inflect(i.e portuguese).
 ```php
 <?php
 
-use Inflect\Inflect;
+use Inflect\Inflect
 
-Inflect::pluralize('pão');                // pães
-Inflect::pluralize('carro');              // carros
+$inflector = new Inflect;
 
-Inflect::singularize('carros');           // carro
-Inflect::singularize('pães');             // pão
+$inflector->pluralize('pão');            // pães
+$inflector->pluralize('carro');          // carros
 
-Inflect::camelize('tablename');           // TableName
-Inflect::camelize('tablename', true);     // tableName
+$inflector->singularize('carros');       // carro
+$inflector->singularize('pães');         // pão
+
+$inflector->camelize('tablename');       // TableName
+$inflector->camelize('tablename', true); // tableName
+```
+
+You can also use it without instantiating the object trought the `Facade` class
+
+```php
+<?php
+
+use Inflect\Facade as Inflect; // Use facade to be able to do static calls
+
+Inflect::pluralize('carro');          // carros
+Inflect::singularize('carros');       // carro
+Inflect::camelize('tablename');       // TableName
 ```
 
 ## Installation

--- a/src/Inflect/Facade.php
+++ b/src/Inflect/Facade.php
@@ -3,7 +3,7 @@
 namespace Inflect;
 
 /**
- * This is a helper class that allows the usage of the Inflect\Inflect trought
+ * This is a helper class that allows the usag of the Inflect\Inflect trought
  * static calls
  *
  * @example
@@ -21,7 +21,7 @@ class Facade
      *
      * @return Inflect
      */
-    protected function getInflector()
+    protected static function getInflector()
     {
         if (!self::$inflector) {
             self::$inflector = new Inflect;
@@ -39,7 +39,7 @@ class Facade
      */
     public static function __callStatic($method, $args)
     {
-        $instance = $this->getInflector();
+        $instance = self::getInflector();
 
         switch (count($args))
         {

--- a/src/Inflect/Facade.php
+++ b/src/Inflect/Facade.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Inflect;
+
+/**
+ * This is a helper class that allows the usage of the Inflect\Inflect trought
+ * static calls
+ *
+ * @example
+ *     // Calling Inflect::plurarize as if it was static
+ *     Inflect\Facade::pluralize('pão')
+ *
+ * @package Inflect
+ */
+class Facade
+{
+    static $inflector;
+
+    /**
+     * Returns an instance of Inflect\Inflect
+     *
+     * @return Inflect
+     */
+    protected function getInflector()
+    {
+        if (!self::$inflector) {
+            self::$inflector = new Inflect;
+        }
+
+        return self::$inflector;
+    }
+
+    /**
+     * Handle dynamic, static calls to the actual inflector instance
+     *
+     * @param  string  $method
+     * @param  array   $args
+     * @return mixed
+     */
+    public static function __callStatic($method, $args)
+    {
+        $instance = $this->getInflector();
+
+        switch (count($args))
+        {
+            case 0:
+                return $instance->$method();
+
+            case 1:
+                return $instance->$method($args[0]);
+
+            default:
+                return call_user_func_array(array($instance, $method), $args);
+        }
+    }
+}

--- a/src/Inflect/Inflect.php
+++ b/src/Inflect/Inflect.php
@@ -88,21 +88,22 @@ class Inflect
      **/
     public static function pluralize($string)
     {
-        if(in_array(strtolower($string), self::$uncountable))
+        if (in_array(strtolower($string), self::$uncountable)) {
             return $string;
-
-        foreach(self::$irregular as $pattern => $result)
-        {
-            $pattern = '/' . $pattern . '$/i';
-
-            if(preg_match($pattern, $string))
-                return preg_replace($pattern, $result, $string);
         }
 
-        foreach(self::$plural as $pattern => $result)
-        {
-            if(preg_match($pattern, $result))
-                return preg_replace($pattern, $result, $string)
+        foreach (self::$irregular as $pattern => $result) {
+            $pattern = '/' . $pattern . '$/i';
+
+            if (preg_match($pattern, $string)) {
+                return preg_replace($pattern, $result, $string);
+            }
+        }
+
+        foreach (self::$plural as $pattern => $result) {
+            if (preg_match($pattern, $result)) {
+                return preg_replace($pattern, $result, $string);
+            }
         }
 
         return $string;
@@ -116,21 +117,22 @@ class Inflect
      **/
     public static function singularize($string)
     {
-        if(in_array(strtolower($string), self::$uncountable))
+        if (in_array(strtolower($string), self::$uncountable)) {
             return $string;
-
-        foreach (self::$irregular as $result => $pattern)
-        {
-            $pattern = '/' . $pattern . '$/i';
-
-            if(preg_match($pattern, $string))
-                return preg_replace($pattern, $result, $string)
         }
 
-        foreach(self::$singular as $pattern => $result)
-        {
-            if(preg_match($pattern, $string))
-                return preg_replace($pattern, $result, $string)
+        foreach (self::$irregular as $result => $pattern) {
+            $pattern = '/' . $pattern . '$/i';
+
+            if (preg_match($pattern, $string)) {
+                return preg_replace($pattern, $result, $string);
+            }
+        }
+
+        foreach (self::$singular as $pattern => $result) {
+            if (preg_match($pattern, $string)) {
+                return preg_replace($pattern, $result, $string);
+            }
         }
 
         return $string;
@@ -144,8 +146,9 @@ class Inflect
      **/
     public static function camelize($string, $uppercase_first_letter = false)
     {
-        if($uppercase_first_letter)
+        if ($uppercase_first_letter) {
             return str_replace(' ', '', ucwords(strtr($string, '_-', ' ')));
+        }
 
         return str_replace(' ', '', lcfirst(strtr($string, '_-', ' ')));
     }

--- a/src/Inflect/Inflect.php
+++ b/src/Inflect/Inflect.php
@@ -2,6 +2,11 @@
 
 namespace Inflect;
 
+/**
+ * Handle words in Portuguese
+ *
+ * @package Inflect
+ */
 class Inflect
 {
 
@@ -86,7 +91,7 @@ class Inflect
      * @param string
      * @return string
      **/
-    public static function pluralize($string)
+    public function pluralize($string)
     {
         if (in_array(strtolower($string), self::$uncountable)) {
             return $string;
@@ -115,7 +120,7 @@ class Inflect
      * @param string
      * @return string
      **/
-    public static function singularize($string)
+    public function singularize($string)
     {
         if (in_array(strtolower($string), self::$uncountable)) {
             return $string;
@@ -144,7 +149,7 @@ class Inflect
      * @param string
      * @return string
      **/
-    public static function camelize($string, $uppercase_first_letter = false)
+    public function camelize($string, $uppercase_first_letter = false)
     {
         if ($uppercase_first_letter) {
             return str_replace(' ', '', ucwords(strtr($string, '_-', ' ')));


### PR DESCRIPTION
I've updated the Inflect\Inflect methods as non-static. I made this in order to be able to use the Inflect as a ["mockable"](http://stackoverflow.com/questions/2357001/phpunit-mock-objects-and-static-methods) external dependency. _(For people that take unit tests too seriously :laughing: )_

Also there is a new `Facade` class to allow static calls

**PS:** Better merge the other PR (#2) first
